### PR TITLE
Fix action path reference in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Install the latest version of earthly:
 
 ```yaml
 - name: Install earthly
-  uses: earthly/setup-earthly@v1
+  uses: earthly/actions-setup@v1
 ```
 
 Install a specific version of earthly:
 
 ```yaml
 - name: Install earthly
-  uses: earthly/setup-earthly@v1
+  uses: earthly/actions-setup@v1
   with:
     version: 0.6.1
 ```
@@ -54,7 +54,7 @@ Install a version that adheres to a semver range
 
 ```yaml
 - name: Install earthly
-  uses: earthly/setup-earthly@v1
+  uses: earthly/actions-setup@v1
   with:
     version: ^0.6.0
 ```


### PR DESCRIPTION
Trying to use `earthly/setup-earthly` from an action fails because that's not the repo name. The official path from GitHub is `earthly/actions-setup`.

```
Unable to resolve action `earthly/setup-earthly@v1`, repository not found
```