### PR TITLE
make cache usage optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,11 @@ inputs:
   version:
     description: "version of earthly to use."
     default: "latest"
+  use-cache:
+    description: "whether to use the cache to store earthly or not"
+    default: "true"
 runs:
   using: node16
   main: dist/setup/index.js
   post: "dist/cache-save/index.js"
+  post-if: inputs.use-cache == 'true'


### PR DESCRIPTION
caching may use a significant amount of storage when using earthly in many jobs (we use it in all our jobs), so it's good to make it optional