### PR TITLE
add github-token to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,8 @@ inputs:
   version:
     description: "version of earthly to use."
     default: "latest"
+  github-token:
+    description: "GitHub token for fetching Earthly version list."
 runs:
   using: node16
   main: dist/setup/index.js


### PR DESCRIPTION
To prevent warnings when using `github-token`:

```
Warning: Unexpected input(s) 'github-token', valid inputs are ['version']
```