### PR TITLE
add `github-token` to README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           version: "latest" # or pin to an specific version, e.g. "0.7.1"
       - uses: actions/checkout@v2
       - name: Docker login # to avoid dockerhub rate-limiting
@@ -39,6 +40,9 @@ Install the latest version of earthly:
 ```yaml
 - name: Install earthly
   uses: earthly/actions-setup@v1
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+
 ```
 
 Install a specific version of earthly:
@@ -47,6 +51,7 @@ Install a specific version of earthly:
 - name: Install earthly
   uses: earthly/actions-setup@v1
   with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
     version: 0.6.1
 ```
 
@@ -56,6 +61,7 @@ Install a version that adheres to a semver range
 - name: Install earthly
   uses: earthly/actions-setup@v1
   with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
     version: ^0.6.0
 ```
 
@@ -73,3 +79,4 @@ The action can be configured with the following arguments:
 - `github-token` (optional) - Token used to query earthly versions.
 - `prerelease` (optional) - allow prerelease versions.
 - `use-cache` (optional) - whether to use the cache to store earthly or not.
+- `github-token` (optional) - GitHub token for fetching earthly version list. Recommended to avoid GitHub API ratelimit.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Install the latest version of earthly:
   uses: earthly/actions-setup@v1
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
-
 ```
 
 Install a specific version of earthly:


### PR DESCRIPTION
This is likely a safe default to prevent people from running into API rate limiting such as in #14 and #22 