### PR TITLE
Renovate configuration - group dependencies in fewer PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,21 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "config:recommended"
-  ]
+  ],
+  labels: [
+    'renovate',
+  ],
+  packageRules: [
+    {
+      // group packages in the same PR according to data source & update type
+      matchManagers: [
+        'npm', 'github-actions',
+      ],
+      groupName: "{{datasource}}_{{updateType}}",
+      addLabels: [
+        '{{datasource}}',
+        '{{updateType}}',
+      ],
+    },
+  ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,9 +12,24 @@
       matchManagers: [
         'npm', 'github-actions',
       ],
-      groupName: "{{datasource}}_{{updateType}}",
+      matchUpdateTypes: [
+        'minor',
+        'patch',
+      ],
+      groupName: "{{datasource}} (non-major)",
       addLabels: [
-        '{{datasource}}',
+        'non-major',
+      ],
+    },
+    {
+      // add major label to major updates
+      matchManagers: [
+        'npm', 'github-actions',
+      ],
+      matchUpdateTypes: [
+        'major',
+      ],
+      addLabels: [
         '{{updateType}}',
       ],
     },


### PR DESCRIPTION
 - Minor and patch upgrades per package type (npm, githuh-actions) will be grouped together.
 - Major upgrades will be opened in individual PRs.