### PR TITLE
Auto update dist for renovate

### DIFF
--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -2,6 +2,7 @@ name: Update Renovate Branch
 
 on:
   pull_request:
+    branches: [ main ]
 
 jobs:
   udpate-renovate-branch:

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -6,9 +6,8 @@ on:
 
 jobs:
   udpate-renovate-branch:
-    name: Update Renovate Branch ${{ github.head_ref }}
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    # && startsWith(github.head_ref, 'renovate/') && github.head_ref == 'renovate[bot]'
+    name: ${{ github.head_ref }}
+    if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/') && github.head_ref == 'renovate[bot]'
     runs-on: ubuntu-latest
     env:
       FORCE_COLOR: 1
@@ -22,13 +21,5 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-      # - name: Docker login (non fork only)
-      #   run: |-
-      #     docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
-      #     docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
-      # - name: Configure Earthly to use mirror (non fork only)
-      #   run: |-
-      #     earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
-      #     mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
       - name: Update Branch
-        run: earthly --ci -P --push --org earthly-technologies +ido-test
+        run: earthly --ci -P --push +update-dist

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -20,13 +20,13 @@ jobs:
         with:
           version: v0.8.6
       - uses: actions/checkout@v4
-      - name: Docker login (non fork only)
-        run: |-
-          docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
-          docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
-      - name: Configure Earthly to use mirror (non fork only)
-        run: |-
-          earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
-          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+      # - name: Docker login (non fork only)
+      #   run: |-
+      #     docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+      #     docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+      # - name: Configure Earthly to use mirror (non fork only)
+      #   run: |-
+      #     earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
+      #     mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
       - name: Update Branch
         run: earthly --ci -P --push --org earthly-technologies +ido-test

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -4,8 +4,12 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  udpate-renovate-branch:
+  update-renovate-branch:
     if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/') && github.head_ref == 'renovate[bot]'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   udpate-renovate-branch:
-    name: ${{ github.head_ref }}
+    name: Update ${{ github.head_ref }}
     if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/') && github.head_ref == 'renovate[bot]'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -1,0 +1,31 @@
+name: Update Renovate Branch
+
+on:
+  pull_request:
+
+jobs:
+  udpate-renovate-branch:
+    name: Update Renovate Branch ${{ github.head_ref }}
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    # && startsWith(github.head_ref, 'renovate/') && github.head_ref == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_CONVERSION_PARALLELISM: "5"
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      EARTHLY_INSTALL_ID: "earthly-actions-setup-githubactions"
+    steps:
+      - uses: earthly/actions/setup-earthly@v1
+        with:
+          version: v0.8.6
+      - uses: actions/checkout@v4
+      - name: Docker login (non fork only)
+        run: |-
+          docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"
+          docker login registry-1.docker.io.mirror.corp.earthly.dev --username "${{ secrets.DOCKERHUB_MIRROR_USERNAME }}" --password "${{ secrets.DOCKERHUB_MIRROR_PASSWORD }}"
+      - name: Configure Earthly to use mirror (non fork only)
+        run: |-
+          earthly config global.buildkit_additional_config "'[registry.\"docker.io\"]
+          mirrors = [\"registry-1.docker.io.mirror.corp.earthly.dev\"]'"
+      - name: Update Branch
+        run: earthly --ci -P --push --org earthly-technologies +ido-test

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           version: v0.8.6
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
       # - name: Docker login (non fork only)
       #   run: |-
       #     docker login --username "${{ secrets.DOCKERHUB_USERNAME }}" --password "${{ secrets.DOCKERHUB_TOKEN }}"

--- a/.github/workflows/renovate-helper.yml
+++ b/.github/workflows/renovate-helper.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   udpate-renovate-branch:
-    name: Update ${{ github.head_ref }}
     if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/') && github.head_ref == 'renovate[bot]'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
       - "main"
       - "releases/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Earthfile
+++ b/Earthfile
@@ -117,11 +117,6 @@ update-dist-for-renovate:
     RUN --push --mount=type=secret,id=$SECRET_PATH,mode=0400,target=/root/.ssh/id_rsa \
          git push origin $branch
 
-ido-test:
-    FROM alpine
-    ARG EARTHLY_GIT_BRANCH
-    RUN --no-cache echo the branch is $EARTHLY_GIT_BRANCH
-
 all:
     BUILD +lint
     BUILD +lint-newline


### PR DESCRIPTION
Once Renovate updates a dependency we need to get the dist directory updated and checked in to the branch.
This PR defines a new target and gh workflow that will update dist and push it to the renovate branch