### PR TITLE
Add --push to release update; add env vars to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ env:
 jobs:
   unit:
     name: earthly +all
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_CONVERSION_PARALLELISM: "5"
+      EARTHLY_INSTALL_ID: "earthly-actions-setup-githubactions"
     strategy:
       matrix:
         platform: [ubuntu-latest]

--- a/.github/workflows/update-major-version.yml
+++ b/.github/workflows/update-major-version.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           ref: ${{ github.ref }}
       - name: Update Branch
-        run: earthly --ci -P +merge-release-to-major-branch --RELEASE_TAG=${{ github.ref }}
+        run: earthly --ci -P --push +merge-release-to-major-branch --RELEASE_TAG=${{ github.ref }}


### PR DESCRIPTION
The dry run v1 branch update seems to work as expected so I'm enabling it for next time, see https://github.com/earthly/actions-setup/actions/runs/8468947677/job/23203111755.

Also updating env vars in test workflow