### PR TITLE
feat: set default github token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,7 @@ inputs:
     default: "true"
   github-token:
     description: "GitHub token for fetching Earthly version list."
+    default: ${{ github.token }}
 runs:
   using: node20
   main: dist/setup/index.js


### PR DESCRIPTION
This adds default `github.token`, which is the same as `secrets.GITHUB_TOKEN` .